### PR TITLE
Additional Fixes

### DIFF
--- a/tuxemon/core/components/event/actions/combat.py
+++ b/tuxemon/core/components/event/actions/combat.py
@@ -134,15 +134,10 @@ class Combat(object):
             npc.monsters.append(current_monster)
 
         # Add our players and start combat
-        #game.state_dict["WORLD"].combat_started = True
-
-        # Add our players and start combat
-        game.push_state("COMBAT", params={
+        game.push_state("TRANSITION", params={
             'players': (game.player1, npc),
-            'combat_type': "trainer"})
-
-        # TODO: transition
-        # game.current_state.start_battle_transition = True
+            'combat_type': "trainer",
+            'screen': game.screen})
 
         # Start some music!
         logger.info("Playing battle music!")
@@ -172,12 +167,10 @@ class Combat(object):
             return False
 
         # Add our players and start combat
-        game.push_state("COMBAT", params={
+        game.push_state("TRANSITION", params={
             'players': (game.player1, npc),
-            'combat_type': "trainer"})
-
-        # TODO: transition
-        # game.state_dict["WORLD"].start_battle_transition = True
+            'combat_type': "trainer",
+            'screen': game.screen})
 
         # Start some music!
         logger.info("Playing battle music!")
@@ -268,16 +261,10 @@ class Combat(object):
             npc.ai = ai.AI()
 
             # Add our players and start combat
-            #game.push_state("COMBAT", params={
-            #    'players': (player1, npc),
-            #    'combat_type': "monster"})
             game.push_state("TRANSITION", params={
                 'players': (player1, npc),
                 'combat_type': "monster",
                 'screen': game.screen})
-
-            # TODO: transition
-            game.current_state.start_battle_transition = True
 
             # Start some music!
             filename = "147066_pokemon.ogg"
@@ -287,8 +274,6 @@ class Combat(object):
             game.current_music["song"] = filename
 
             # Stop the player's movement
-            # TODO: menu blocking
-            # game.state_dict["WORLD"].menu_blocking = True
             player1.moving = False
             player1.direction = {'down': False, 'left': False, 'right': False, 'up': False}
 

--- a/tuxemon/core/components/event/actions/combat.py
+++ b/tuxemon/core/components/event/actions/combat.py
@@ -268,9 +268,13 @@ class Combat(object):
             npc.ai = ai.AI()
 
             # Add our players and start combat
-            game.push_state("COMBAT", params={
+            #game.push_state("COMBAT", params={
+            #    'players': (player1, npc),
+            #    'combat_type': "monster"})
+            game.push_state("TRANSITION", params={
                 'players': (player1, npc),
-                'combat_type': "monster"})
+                'combat_type': "monster",
+                'screen': game.screen})
 
             # TODO: transition
             game.current_state.start_battle_transition = True

--- a/tuxemon/core/components/event/actions/core.py
+++ b/tuxemon/core/components/event/actions/core.py
@@ -232,5 +232,4 @@ class Core(object):
 
         # Don't override previous state if we are still in the state.
         if game.state_name != action[1]:
-            game.pop_state()
             game.push_state(action[1])

--- a/tuxemon/core/components/event/conditions/music.py
+++ b/tuxemon/core/components/event/conditions/music.py
@@ -60,12 +60,7 @@ class Music(object):
          'y': 0}
 
         """
-
-        world = game.current_state
-        if (world.start_battle_transition or
-                world.battle_transition_in_progress or
-                # game.state_name == "COMBAT" or game.current_state.done):
-                game.state_name == "COMBAT"):
+        if game.state_name == "TRANSITION" or game.state_name == "COMBAT":
             return True
 
         if game.current_music["song"] == condition["parameters"] and mixer.music.get_busy():

--- a/tuxemon/core/components/menu/pc_menu.py
+++ b/tuxemon/core/components/menu/pc_menu.py
@@ -30,7 +30,6 @@
 """This module contains the PC Menu
 """
 from core.components.menu import Menu
-from core import prepare
 
 
 class PCMenu(Menu):

--- a/tuxemon/core/components/networking.py
+++ b/tuxemon/core/components/networking.py
@@ -458,7 +458,7 @@ class TuxemonClient():
 
         if self.client.registered and not self.populated:
             self.game.isclient = True
-            self.game.state_dict["PC"].multiplayer_join_success_menu.text = ["Success!"]
+            self.game.current_state.multiplayer_join_success_menu.text = ["Success!"]
             self.populate_player()
 
         self.check_notify()
@@ -530,7 +530,8 @@ class TuxemonClient():
                 del self.client.event_notifies[euuid]
 
             if event_data["type"] == "NOTIFY_CLIENT_INTERACTION":
-                self.game.state_dict["WORLD"].handle_interaction(event_data, self.client.registry)
+                world = self.game.get_world_state()
+                world.handle_interaction(event_data, self.client.registry)
                 del self.client.event_notifies[euuid]
 
     def join_multiplayer(self, time_delta):
@@ -611,7 +612,7 @@ class TuxemonClient():
         """
         if not event_type in self.event_list:
             self.event_list[event_type] = 0
-        pd = self.game.state_dict["WORLD"].player1.__dict__
+        pd = prepare.player1.__dict__
         map_name = self.game.get_map_name()
         event_data = {"type": event_type,
                       "event_number": self.event_list[event_type],
@@ -646,7 +647,7 @@ class TuxemonClient():
         """
         if not event_type in self.event_list:
             self.event_list[event_type] = 0
-        pd = self.game.state_dict["WORLD"].player1.__dict__
+        pd = prepare.player1.__dict__
         map_name = self.game.get_map_name()
         event_data = {"type": event_type,
                       "event_number": self.event_list[event_type],
@@ -771,7 +772,7 @@ class TuxemonClient():
         for client_id in self.client.registry:
             if self.client.registry[client_id]["sprite"] == sprite: cuuid = client_id
 
-        pd = self.game.state_dict["WORLD"].player1.__dict__
+        pd = prepare.player1.__dict__
         event_data = {"type": event_type,
                       "event_number": self.event_list[event_type],
                       "interaction": interaction,
@@ -854,18 +855,19 @@ def update_client(sprite, char_dict, game):
     :returns: None
 
     """
+    world = game.get_world_state()
     for item in char_dict:
 
         sprite.__dict__[item] = char_dict[item]
 
         # Get the pixel position of our tile position.
         if item == "tile_pos":
-            tile_size = game.state_dict["WORLD"].tile_size
+            tile_size = prepare.TILE_SIZE
             position = [char_dict["tile_pos"][0] * tile_size[0],
                         char_dict["tile_pos"][1] * tile_size[1]
                         ]
-            global_x = game.state_dict["WORLD"].global_x
-            global_y = game.state_dict["WORLD"].global_y
+            global_x = world.global_x
+            global_y = world.global_y
             abs_position = [position[0] + global_x, position[1] + (global_y-tile_size[1])]
             sprite.__dict__["position"] = abs_position
 

--- a/tuxemon/core/components/networking.py
+++ b/tuxemon/core/components/networking.py
@@ -531,6 +531,8 @@ class TuxemonClient():
 
             if event_data["type"] == "NOTIFY_CLIENT_INTERACTION":
                 world = self.game.get_world_state()
+                if not world:
+                    return
                 world.handle_interaction(event_data, self.client.registry)
                 del self.client.event_notifies[euuid]
 
@@ -856,8 +858,10 @@ def update_client(sprite, char_dict, game):
 
     """
     world = game.get_world_state()
-    for item in char_dict:
+    if not world:
+        return
 
+    for item in char_dict:
         sprite.__dict__[item] = char_dict[item]
 
         # Get the pixel position of our tile position.

--- a/tuxemon/core/control.py
+++ b/tuxemon/core/control.py
@@ -608,7 +608,10 @@ class Control(StateManager):
         :returns: None
 
         """
-        world = self.current_state
+        world = self.get_world_state()
+        if not world:
+            return
+
         world.npcs = []
         world.npcs_off_map = []
         for client in registry:
@@ -640,12 +643,20 @@ class Control(StateManager):
         :returns: map_name
 
         """
-        world = self.current_state
+        world = self.get_world_state()
+        if not world:
+            return
+
         map_path = world.current_map.filename
         map_name = str(map_path.replace(prepare.BASEDIR, ""))
         map_name = str(map_name.replace("resources/maps/", ""))
         return map_name
 
+    def get_world_state(self):
+        for state in self.state_stack:
+            if state.__module__ == "core.states.world":
+                return state
+        return None
 
 class PygameControl(Control):
     pass

--- a/tuxemon/core/main.py
+++ b/tuxemon/core/main.py
@@ -65,6 +65,5 @@ def headless():
     control.auto_state_discovery()
 
     # patch the control to use the headless world
-    control.state_dict["WORLD"] = control.state_dict["HEADLESS"]
-    control.push_state("WORLD")
+    control.push_state("HEADLESS")
     control.main()

--- a/tuxemon/core/states/combat/__init__.py
+++ b/tuxemon/core/states/combat/__init__.py
@@ -448,35 +448,6 @@ class COMBAT(state.State):
         pprint.pprint(ui)
 
 
-    def shutdown(self):
-        """Called when combat ends to clean up the previous combat variables.
-
-        :param: None
-
-        :rtype: None
-        :returns: None
-
-        """
-        self.players = []
-        self.combat_type = None
-        self.current_players = {'player': {}, 'opponent': {}}
-        self.current_players['player']['health_changed'] = False
-        self.current_players['opponent']['health_changed'] = False
-        self.turn_in_progress = False
-        self.status_check_in_progress = False
-        self.status_check_completed = False
-        self.decision_phase = True
-        self.action_phase = False
-
-        self.action_menu.interactable = True
-        self.action_menu.visible = True
-        self.info_menu.visible = True
-        self.info_menu.text = "  "
-        self.info_menu.elapsed_time = self.info_menu.delay  # Reset the window delay
-
-        self.state = "decision phase"
-
-
     def update(self, screen, keys, current_time, time_delta):
         """The primary game loop that executes all game functions every frame.
 
@@ -793,19 +764,7 @@ class COMBAT(state.State):
 
                     # Exit combat for now. In the future, we'll check for trainer battle and do a
                     # roll, etc.
-
-                    # Teleport the player and end combat
-                    #mapname = "pallet_town-room.tmx"
-                    #position_x = "1"
-                    #position_y = "3"
-                    #parameters = [None, mapname + "," + position_x + "," + position_y]
-
-                    event_engine = game.event_engine
-                    #game.event_engine.action.fadeout_music(game, [None, 1000])
-                    event_engine.actions["fadeout_music"]["method"](game, [None, 1000])
-                    #game.event_engine.action.teleport(game, parameters)
-                    game.pop_state()
-
+                    self.end_combat()
 
             ### Fight Menu Events ###
             elif self.fight_menu.interactable:
@@ -1044,11 +1003,7 @@ class COMBAT(state.State):
 
         # Handle when all monsters in the player's party have fainted
         if (self.state == "lost" or self.state == "won" or self.state == "captured") and self.info_menu.elapsed_time > self.info_menu.delay:
-
-            fadeout_music = game.event_engine.actions["fadeout_music"]["method"]
-            fadeout_music(game, [None, 1000])
-
-            self.game.pop_state()
+            self.end_combat()
 
 
         #######################################################
@@ -1395,6 +1350,14 @@ class COMBAT(state.State):
         self.ui[player_mon_name].position = [
         self.ui[player_hp_ui].position[0] + (14 * prepare.SCALE),
         self.ui[player_hp_ui].position[1] + (6 * prepare.SCALE)]
+
+    def end_combat(self):
+        # TODO: End combat differently depending on winning or losing
+        event_engine = self.game.event_engine
+        event_engine.actions["fadeout_music"]["method"](self.game, [None, 1000])
+        self.game.pop_state()
+
+
 
 
 if __name__ == "__main__":

--- a/tuxemon/core/states/pc/__init__.py
+++ b/tuxemon/core/states/pc/__init__.py
@@ -38,7 +38,7 @@ from core.components.menu import pc_menu
 
 # Create a logger for optional handling of debug messages.
 logger = logging.getLogger(__name__)
-logger.debug("states.start successfully imported")
+logger.debug("states.successfully imported")
 
 
 class PC(state.State):
@@ -46,8 +46,6 @@ class PC(state.State):
     """
 
     def startup(self, params=None):
-        from core.components import menu
-
         # Provide an instance of the scene manager to this scene.
         self.previous_menu = None
         self.menu_blocking = True
@@ -143,7 +141,6 @@ class PC(state.State):
             menu.pos_x = (self.resolution[0] / 2) - (menu.size_x/2)
             menu.pos_y = (self.resolution[1] / 2) - (menu.size_y/2)
 
-
     def update(self, screen, keys, current_time, time_delta):
         """Update function for state.
 
@@ -168,9 +165,7 @@ class PC(state.State):
         435
 
         """
-
         self.draw()
-
 
     def get_event(self, event):
         """Processes events that were passed from the main event loop.
@@ -201,7 +196,6 @@ class PC(state.State):
         elif self.pc_menu.interactable:
             self.game.get_menu_event(self.pc_menu, event)
 
-
     def draw(self):
         """Draws the start screen to the screen.
 
@@ -218,19 +212,18 @@ class PC(state.State):
         self.pc_menu.draw_textItem(
                 ["MULTIPLAYER", "LOG OFF"])
 
-
         if self.multiplayer_menu.visible:
             self.multiplayer_menu.draw()
             self.multiplayer_menu.draw_textItem(
                 ["JOIN", "HOST"])
 
-
         if self.multiplayer_join_menu.visible:
             self.multiplayer_join_menu.draw()
             self.multiplayer_join_menu.draw_textItem(self.game.client.server_list)
 
-            # If no options are selected because there were no items when the menu was populated,
-            # and there are items in the list to select, set the selected item to the top of the list.
+            # If no options are selected because there were no items when
+            # the menu was populated, and there are items in the list to
+            # select, set the selected item to the top of the list.
             if self.multiplayer_join_menu.selected_menu_item <= 0 and \
             len(self.multiplayer_join_menu.menu_items) > 0:
                 self.multiplayer_join_menu.selected_menu_item = 0
@@ -242,8 +235,3 @@ class PC(state.State):
         if self.multiplayer_host_menu.visible:
             self.multiplayer_host_menu.draw()
             self.multiplayer_host_menu.draw_textItem(self.multiplayer_host_menu.text)
-
-
-
-
-

--- a/tuxemon/core/states/transition/__init__.py
+++ b/tuxemon/core/states/transition/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Tuxemon
-# Copyright (C) 2014, William Edwards <shadowapex@gmail.com>,
+# Copyright (C) 2015, William Edwards <shadowapex@gmail.com>,
 #                     Benjamin Bean <superman2k5@gmail.com>
 #
 # This file is part of Tuxemon.
@@ -25,7 +25,7 @@
 # William Edwards <shadowapex@gmail.com>
 #
 #
-# core.states.start Handles the splash screen and start menu.
+# core.states.transition Handles the battle transition.
 #
 #
 
@@ -42,7 +42,7 @@ logger.debug("states.transition successfully imported")
 
 
 class TRANSITION(state.State):
-    """ The state responsible for the splash screen and start menu.
+    """ The state responsible for the battle transitions.
     """
 
     def startup(self, params=None):

--- a/tuxemon/core/states/transition/__init__.py
+++ b/tuxemon/core/states/transition/__init__.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Tuxemon
+# Copyright (C) 2014, William Edwards <shadowapex@gmail.com>,
+#                     Benjamin Bean <superman2k5@gmail.com>
+#
+# This file is part of Tuxemon.
+#
+# Tuxemon is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Tuxemon is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Tuxemon.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Contributor(s):
+#
+# William Edwards <shadowapex@gmail.com>
+#
+#
+# core.states.start Handles the splash screen and start menu.
+#
+#
+
+import logging
+import pygame
+
+from core import prepare
+from core import state
+
+
+# Create a logger for optional handling of debug messages.
+logger = logging.getLogger(__name__)
+logger.debug("states.transition successfully imported")
+
+
+class TRANSITION(state.State):
+    """ The state responsible for the splash screen and start menu.
+    """
+
+    def startup(self, params=None):
+        self.screen = params["screen"]
+        self.combat_params = params
+
+        self.original_surface = self.screen.copy()
+        self.transition_surface = pygame.Surface(prepare.SCREEN_SIZE)
+        self.transition_surface.fill((255, 255, 255))
+        self.flash_time = 0.2  # Time in seconds between flashes
+        self.battle_flash_state = "up"
+        self.battle_transition_alpha = 0
+
+        self.max_battle_flash_count = 7
+        self.battle_flash_count = 0
+
+        logger.info("Initializing battle transition")
+        self.game.rumble.rumble(-1, length=1.5)
+
+    def update(self, screen, keys, current_time, time_delta):
+        """Update function for state.
+
+        :param surface: The pygame.Surface of the screen to draw to.
+        :param keys: List of keys from pygame.event.get().
+        :param current_time: The amount of time that has passed.
+
+        :type surface: pygame.Surface
+        :type keys: Tuple
+        :type current_time: Integer
+
+        :rtype: None
+        :returns: None
+
+        **Examples:**
+
+        >>> surface
+        <Surface(1280x720x32 SW)>
+        >>> keys
+        (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ...
+        >>> current_time
+        435
+
+        """
+        logger.info("Battle transition!")
+
+        # self.battle_transition_alpha
+        if self.battle_flash_state == "up":
+            self.battle_transition_alpha += (
+                255 * ((time_delta) / self.flash_time))
+
+        elif self.battle_flash_state == "down":
+            self.battle_transition_alpha -= (
+                255 * ((time_delta) / self.flash_time))
+
+        if self.battle_transition_alpha >= 255:
+            self.battle_flash_state = "down"
+            self.battle_flash_count += 1
+
+        elif self.battle_transition_alpha <= 0:
+            self.battle_flash_state = "up"
+            self.battle_flash_count += 1
+
+        # If we've hit our max number of flashes, stop the battle
+        # transition animation.
+        if self.battle_flash_count > self.max_battle_flash_count:
+            logger.info("Flashed " + str(self.battle_flash_count) +
+                " times. Stopping transition.")
+            self.game.pop_state()
+            self.game.push_state("COMBAT", params=self.combat_params)
+
+        self.draw()
+
+
+    def get_event(self, event):
+        """Processes events that were passed from the main event loop.
+        Must be overridden in children.
+
+        :param event: A pygame key event from pygame.event.get()
+
+        :type event: PyGame Event
+
+        :rtype: None
+        :returns: None
+
+        """
+        pass
+
+
+    def draw(self):
+        """Draws the start screen to the screen.
+
+        :param None:
+        :type None:
+
+        :rtype: None
+        :returns: None
+
+        """
+        # Blit the original surface to the screen.
+        self.game.screen.blit(self.original_surface, (0, 0))
+
+        # Set the alpha of the screen and fill the screen with white at
+        # that alpha level.
+        self.transition_surface.set_alpha(self.battle_transition_alpha)
+        self.screen.blit(self.transition_surface, (0, 0))
+
+

--- a/tuxemon/core/states/world/__init__.py
+++ b/tuxemon/core/states/world/__init__.py
@@ -367,25 +367,6 @@ class WORLD(state.State):
         # the middle of a transition.
         self.delayed_facing = None
 
-        # Variables used for battle transition animation. The battle
-        # transition animation works by filling the screen with white at a
-        # certain alpha level to create flashing.
-        self.start_battle_transition = False    # Kick-off the transition.
-        self.battle_transition_in_progress = False
-
-        # Set the alpha level that the white screen will have.
-        self.battle_transition_alpha = 0
-
-        # Set the number of times the screen will flash before starting combat
-        self.max_battle_flash_count = 6
-
-        # Keep track of the current number of flashes that have passed
-        self.battle_flash_count = 0
-
-        # Either "up" or "down" indicating whether we are adding or
-        # subtracting alpha levels.
-        self.battle_flash_state = "up"
-
         ######################################################################
         #                          Collision Map                             #
         ######################################################################
@@ -454,12 +435,6 @@ class WORLD(state.State):
         for menu in self.menus:
             menu.interactable = False
             menu.visible = False
-
-        # Clear our next screen and any combat related variables.
-        self.combat_started = False
-        self.start_battle_transition = False
-        self.battle_transition_in_progress = False
-
 
     def update(self, screen, keys, current_time, time_delta):
         """The primary game loop that executes the world's game functions every frame.
@@ -1107,52 +1082,6 @@ class WORLD(state.State):
         :returns: None
 
         """
-
-        if self.start_battle_transition:
-            logger.info("Initializing battle transition")
-            self.game.rumble.rumble(-1, length=1.5)
-            self.battle_transition_in_progress = True
-            self.transition_surface = pygame.Surface(self.resolution)
-            self.transition_surface.fill((255, 255, 255))
-            self.start_battle_transition = False
-
-            # Stop player map movement
-            self.menu_blocking = True
-
-        if self.battle_transition_in_progress:
-            logger.info("Battle transition!")
-
-            flash_time = 0.2  # Time in seconds between flashes
-
-            # self.battle_transition_alpha
-            if self.battle_flash_state == "up":
-                self.battle_transition_alpha += (
-                    255 * ((self.time_passed_seconds) / flash_time))
-
-            elif self.battle_flash_state == "down":
-                self.battle_transition_alpha -= (
-                    255 * ((self.time_passed_seconds) / flash_time))
-
-            if self.battle_transition_alpha >= 255:
-                self.battle_flash_state = "down"
-                self.battle_flash_count += 1
-            elif self.battle_transition_alpha <= 0:
-                self.battle_flash_state = "up"
-                self.battle_flash_count += 1
-
-            # If we've hit our max number of flashes, stop the battle
-            # transition animation.
-            if self.battle_flash_count > self.max_battle_flash_count:
-                logger.info("Flashed " + str(self.battle_flash_count) +
-                    " times. Stopping transition.")
-                self.battle_transition_in_progress = False
-                self.battle_flash_count = 0
-                self.game.pop_state()
-
-            # Set the alpha of the screen and fill the screen with white at
-            # that alpha level.
-            self.transition_surface.set_alpha(self.battle_transition_alpha)
-            self.screen.blit(self.transition_surface, (0, 0))
 
         # FUCKIN' MATH! 0 = NO ALPHA NOT 255 DAMNIT BILLY!
         # if the value of start_transition event is set to true

--- a/tuxemon/resources/db/encounter/1.json
+++ b/tuxemon/resources/db/encounter/1.json
@@ -3,7 +3,7 @@
     "monsters": [
         {
             "monster_id": 1, 
-            "encounter_rate": 5, 
+            "encounter_rate": 50, 
             "level_range": [
                 1, 
                 6
@@ -11,7 +11,7 @@
         },
        {
             "monster_id": 2, 
-            "encounter_rate": 5, 
+            "encounter_rate": 50, 
             "level_range": [
                 1, 
                 6
@@ -27,7 +27,7 @@
         },
         {
             "monster_id": 4, 
-            "encounter_rate": 5, 
+            "encounter_rate": 50, 
             "level_range": [
                 1, 
                 6

--- a/tuxemon/tuxemon.cfg
+++ b/tuxemon/tuxemon.cfg
@@ -13,7 +13,7 @@ controller_transparency = 45
 starting_map = bedroom_test.tmx
 starting_position_x = 3
 starting_position_y = 3
-cli_enabled = 1
+cli_enabled = 0
 net_controller_enabled = 1
 
 [player]


### PR DESCRIPTION
I've been able to remove just about all the references to the `state_dict` and I moved the battle transition out into its own state. Multiplayer still assumes that the "WORLD" state is somewhere in the stack, but in the future we might be able to put its dependencies in the `Control` class so it doesn't need to directly access a separate state.

I actually streamed on Twitch while making some of these changes :P :
https://www.youtube.com/watch?v=ImSTQ86fvAo
