### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/tuxemon/core/components/menu/__init__.py
+++ b/tuxemon/core/components/menu/__init__.py
@@ -426,15 +426,15 @@ class Menu(UserInterface):
 
         # If the position isn't specified in the function, set it to the current intance's
         # position. Otherwise, set it to the relative position
-        if (pos_x == None):
+        if (pos_x is None):
             pos_x = self.pos_x
         else:
             pos_x = pos_x + self.pos_x
-        if (pos_y == None):
+        if (pos_y is None):
             pos_y = self.pos_y
         else:
             pos_y = pos_y + self.pos_y
-        if text == None:
+        if text is None:
             text = self.text
 
         # Set up our font that we're going to use, including size, color, etc.

--- a/tuxemon/core/components/player.py
+++ b/tuxemon/core/components/player.py
@@ -864,7 +864,7 @@ class PathfindNode():
     
     def __str__(self):
         s = str(self.value)
-        if self.parent != None:
+        if self.parent is not None:
             s += str(self.parent)
         return s
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bitcraft:Tuxemon?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:bitcraft:Tuxemon?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
